### PR TITLE
Add is_dir helper function to metadata

### DIFF
--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -193,8 +193,7 @@ fn embed_file(rel_path: &str, full_canonical_path: &str) -> TokenStream2 {
 
           Some(rust_embed::EmbeddedFile {
               data: std::borrow::Cow::from(bytes),
-              metadata: rust_embed::Metadata::__rust_embed_new([#(#hash),*], #last_modified),
-              is_dir: #is_dir
+              metadata: rust_embed::Metadata::__rust_embed_new([#(#hash),*], #last_modified, #is_dir),
           })
       }
   }

--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -6,7 +6,7 @@ extern crate proc_macro;
 
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
-use std::{env, fs, path::Path};
+use std::{env, path::Path};
 use syn::{Data, DeriveInput, Fields, Lit, Meta, MetaNameValue};
 
 fn embedded(ident: &syn::Ident, folder_path: String, prefix: Option<&str>, includes: &[String], excludes: &[String]) -> TokenStream2 {

--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -6,7 +6,7 @@ extern crate proc_macro;
 
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
-use std::{env, path::Path};
+use std::{env, fs, path::Path};
 use syn::{Data, DeriveInput, Fields, Lit, Meta, MetaNameValue};
 
 fn embedded(ident: &syn::Ident, folder_path: String, prefix: Option<&str>, includes: &[String], excludes: &[String]) -> TokenStream2 {
@@ -170,6 +170,7 @@ fn generate_assets(ident: &syn::Ident, folder_path: String, prefix: Option<Strin
 fn embed_file(rel_path: &str, full_canonical_path: &str) -> TokenStream2 {
   let file = rust_embed_utils::read_file_from_fs(Path::new(full_canonical_path)).expect("File should be readable");
   let hash = file.metadata.sha256_hash();
+  let is_dir = file.metadata.is_dir();
   let last_modified = match file.metadata.last_modified() {
     Some(last_modified) => quote! { Some(#last_modified) },
     None => quote! { None },
@@ -192,7 +193,8 @@ fn embed_file(rel_path: &str, full_canonical_path: &str) -> TokenStream2 {
 
           Some(rust_embed::EmbeddedFile {
               data: std::borrow::Cow::from(bytes),
-              metadata: rust_embed::Metadata::__rust_embed_new([#(#hash),*], #last_modified)
+              metadata: rust_embed::Metadata::__rust_embed_new([#(#hash),*], #last_modified),
+              is_dir: #is_dir
           })
       }
   }

--- a/readme.md
+++ b/readme.md
@@ -55,6 +55,7 @@ pub struct EmbeddedFile {
 pub struct Metadata {
   hash: [u8; 32],
   last_modified: Option<u64>,
+  is_dir: bool,
 }
 ```
 

--- a/tests/interpolated_path.rs
+++ b/tests/interpolated_path.rs
@@ -19,7 +19,7 @@ fn iter_works() {
     assert!(Asset::get(file.as_ref()).is_some());
     num_files += 1;
   }
-  assert_eq!(num_files, 6);
+  assert_eq!(num_files, 8);
 }
 
 #[test]
@@ -32,6 +32,6 @@ fn trait_works_generic_helper<E: rust_embed::RustEmbed>() {
     assert!(E::get(file.as_ref()).is_some());
     num_files += 1;
   }
-  assert_eq!(num_files, 6);
+  assert_eq!(num_files, 8);
   assert!(E::get("gg.html").is_none(), "gg.html should not exist");
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -29,7 +29,7 @@ fn iter_works() {
     assert!(Asset::get(file.as_ref()).is_some());
     num_files += 1;
   }
-  assert_eq!(num_files, 6);
+  assert_eq!(num_files, 8);
 }
 
 #[test]
@@ -42,6 +42,6 @@ fn trait_works_generic_helper<E: rust_embed::RustEmbed>() {
     assert!(E::get(file.as_ref()).is_some());
     num_files += 1;
   }
-  assert_eq!(num_files, 6);
+  assert_eq!(num_files, 8);
   assert!(E::get("gg.html").is_none(), "gg.html should not exist");
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -10,6 +10,7 @@ fn get_works() {
   assert!(Asset::get("index.html").is_some(), "index.html should exist");
   assert!(Asset::get("gg.html").is_none(), "gg.html should not exist");
   assert!(Asset::get("images/llama.png").is_some(), "llama.png should exist");
+  assert!(Asset::get("images").is_some(), "images should exist");
 }
 
 /// Using Windows-style path separators (`\`) is acceptable

--- a/tests/metadata.rs
+++ b/tests/metadata.rs
@@ -30,7 +30,7 @@ fn last_modified_is_accurate() {
 fn is_dir_is_accurate() {
   let index_file: EmbeddedFile = Asset::get("index.html").expect("index.html exists");
   let doc_file: EmbeddedFile = Asset::get("images/doc.txt").expect("doc.txt exists");
-  let images_folder: EmbeddedFile = Asset::get("images/").expect("images exists");
+  let images_folder: EmbeddedFile = Asset::get("images").expect("images exists");
 
   assert_eq!(index_file.metadata.is_dir(), false);
   assert_eq!(doc_file.metadata.is_dir(), false);

--- a/tests/metadata.rs
+++ b/tests/metadata.rs
@@ -25,3 +25,14 @@ fn last_modified_is_accurate() {
 
   assert_eq!(index_file.metadata.last_modified(), Some(expected_datetime_utc));
 }
+
+#[test]
+fn is_dir_is_accurate() {
+  let index_file: EmbeddedFile = Asset::get("index.html").expect("index.html exists");
+  let doc_file: EmbeddedFile = Asset::get("images/doc.txt").expect("doc.txt exists");
+  let images_folder: EmbeddedFile = Asset::get("images/").expect("images exists");
+
+  assert_eq!(index_file.metadata.is_dir(), false);
+  assert_eq!(doc_file.metadata.is_dir(), false);
+  assert!(images_folder.metadata.is_dir());
+}

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -114,7 +114,7 @@ impl Metadata {
 }
 
 pub fn read_file_from_fs(file_path: &Path) -> io::Result<EmbeddedFile> {
-  let data = fs::read(file_path)?;
+  let data = if !file_path.is_dir() { fs::read(file_path)? } else { Vec::new() };
   let data = Cow::from(data);
 
   let mut hasher = sha2::Sha256::new();

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -10,6 +10,7 @@ use std::{fs, io};
 pub struct FileEntry {
   pub rel_path: String,
   pub full_canonical_path: String,
+  pub is_dir: bool,
 }
 
 #[cfg(not(feature = "include-exclude"))]
@@ -58,10 +59,10 @@ pub fn get_files<'patterns>(folder_path: String, includes: &'patterns [&str], ex
     .sort_by_file_name()
     .into_iter()
     .filter_map(|e| e.ok())
-    .filter(|e| e.file_type().is_file())
     .filter_map(move |e| {
       let rel_path = path_to_str(e.path().strip_prefix(&folder_path).unwrap());
       let full_canonical_path = path_to_str(std::fs::canonicalize(e.path()).expect("Could not get canonical path"));
+      let is_dir = e.file_type().is_dir();
 
       let rel_path = if std::path::MAIN_SEPARATOR == '\\' {
         rel_path.replace('\\', "/")
@@ -70,7 +71,11 @@ pub fn get_files<'patterns>(folder_path: String, includes: &'patterns [&str], ex
       };
 
       if is_path_included(&rel_path, includes, excludes) {
-        Some(FileEntry { rel_path, full_canonical_path })
+        Some(FileEntry {
+          rel_path,
+          full_canonical_path,
+          is_dir,
+        })
       } else {
         None
       }

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -108,7 +108,9 @@ impl Metadata {
   }
 
   /// Check if an entry is a directory
-  pub fn is_dir(&self) -> bool { self.is_dir }
+  pub fn is_dir(&self) -> bool {
+    self.is_dir
+  }
 }
 
 pub fn read_file_from_fs(file_path: &Path) -> io::Result<EmbeddedFile> {

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -87,12 +87,13 @@ pub struct EmbeddedFile {
 pub struct Metadata {
   hash: [u8; 32],
   last_modified: Option<u64>,
+  is_dir: bool,
 }
 
 impl Metadata {
   #[doc(hidden)]
-  pub fn __rust_embed_new(hash: [u8; 32], last_modified: Option<u64>) -> Self {
-    Self { hash, last_modified }
+  pub fn __rust_embed_new(hash: [u8; 32], last_modified: Option<u64>, is_dir: bool) -> Self {
+    Self { hash, last_modified, is_dir }
   }
 
   /// The SHA256 hash of the file
@@ -105,6 +106,9 @@ impl Metadata {
   pub fn last_modified(&self) -> Option<u64> {
     self.last_modified
   }
+
+  /// Check if an entry is a directory
+  pub fn is_dir(&self) -> bool { self.is_dir }
 }
 
 pub fn read_file_from_fs(file_path: &Path) -> io::Result<EmbeddedFile> {
@@ -132,6 +136,7 @@ pub fn read_file_from_fs(file_path: &Path) -> io::Result<EmbeddedFile> {
     metadata: Metadata {
       hash,
       last_modified: source_date_epoch.or(last_modified),
+      is_dir: fs::metadata(file_path)?.is_dir(),
     },
   })
 }


### PR DESCRIPTION
Jumping on #170, adding an `is_dir` helper function based on fs metadata.