### PR TITLE
Fix failing axum-spa example

### DIFF
--- a/examples/axum-spa/main.rs
+++ b/examples/axum-spa/main.rs
@@ -1,8 +1,7 @@
 use axum::{
   body::{boxed, Full},
-  handler::Handler,
   http::{header, StatusCode, Uri},
-  response::Response,
+  response::{IntoResponse, Response},
   routing::Router,
 };
 use rust_embed::RustEmbed;
@@ -16,14 +15,14 @@ struct Assets;
 
 #[tokio::main]
 async fn main() {
-  let app = Router::new().fallback(static_handler.into_service());
+  let app = Router::new().fallback(static_handler);
 
   let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
   println!("listening on {}", addr);
   axum::Server::bind(&addr).serve(app.into_make_service()).await.unwrap();
 }
 
-async fn static_handler(uri: Uri) -> Response {
+async fn static_handler(uri: Uri) -> impl IntoResponse {
   let path = uri.path().trim_start_matches('/');
 
   if path.is_empty() || path == INDEX_HTML {

--- a/examples/axum.rs
+++ b/examples/axum.rs
@@ -1,6 +1,5 @@
 use axum::{
   body::{boxed, Full},
-  handler::HandlerWithoutStateExt,
   http::{header, StatusCode, Uri},
   response::{Html, IntoResponse, Response},
   routing::{get, Router},
@@ -14,7 +13,7 @@ async fn main() {
   let app = Router::new()
     .route("/", get(index_handler))
     .route("/index.html", get(index_handler))
-    .route_service("/dist/*file", static_handler.into_service())
+    .route("/dist/*file", get(static_handler))
     .fallback_service(get(not_found));
 
   // Start listening on the given address.


### PR DESCRIPTION
Before this change, running `cargo run --example axum --features=axum-ex` would error with
![image](https://user-images.githubusercontent.com/14093962/212387760-1ec60e6d-bd6a-4b59-b5ff-6cf4fd4466e5.png)

This change fixes that error.