### PR TITLE
Fix salvo example missing feature requirements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,11 @@ name = "poem"
 path = "examples/poem.rs"
 required-features = ["poem-ex"]
 
+[[example]]
+name = "salvo"
+path = "examples/salvo.rs"
+required-features = ["salvo-ex"]
+
 [[test]]
 name = "interpolated_path"
 path = "tests/interpolated_path.rs"


### PR DESCRIPTION
When running `cargo test` without `--all-features` the tests will fail with a load of `failed to resolve` errors as the `salvo-ex` feature is not enabled. Adding 
```toml
[[example]]
name = "salvo"
path = "examples/salvo.rs"
required-features = ["salvo-ex"]
```
to the readme will prevent the example from running unless the required feature is enabled.