### PR TITLE
Fix #206

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ path = "tests/mime_guess.rs"
 required-features = ["mime-guess"]
 
 [dependencies]
-walkdir = "2.3.1"
+walkdir = "2.3.2"
 rust-embed-impl = { version = "6.3.1", path = "impl"}
 rust-embed-utils = { version = "7.3.0", path = "utils"}
 


### PR DESCRIPTION
sort_by_file_name() requires walkdir v2.3.2