### PR TITLE
feat: Store file contents statically and use binary search for lookup.

### DIFF
--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -100,7 +100,7 @@ impl Metadata {
       hash,
       last_modified,
       #[cfg(feature = "mime-guess")]
-      mimetype: mimetype.into(),
+      mimetype: Cow::Borrowed(mimetype),
     }
   }
 

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -78,12 +78,14 @@ pub fn get_files<'patterns>(folder_path: String, includes: &'patterns [&str], ex
 }
 
 /// A file embedded into the binary
+#[derive(Clone)]
 pub struct EmbeddedFile {
   pub data: Cow<'static, [u8]>,
   pub metadata: Metadata,
 }
 
 /// Metadata about an embedded file
+#[derive(Clone)]
 pub struct Metadata {
   hash: [u8; 32],
   last_modified: Option<u64>,
@@ -93,7 +95,7 @@ pub struct Metadata {
 
 impl Metadata {
   #[doc(hidden)]
-  pub fn __rust_embed_new(hash: [u8; 32], last_modified: Option<u64>, #[cfg(feature = "mime-guess")] mimetype: &'static str) -> Self {
+  pub const fn __rust_embed_new(hash: [u8; 32], last_modified: Option<u64>, #[cfg(feature = "mime-guess")] mimetype: &'static str) -> Self {
     Self {
       hash,
       last_modified,


### PR DESCRIPTION
For large directories, RustEmbed generates large amounts of LLVM IR. This is mostly caused by use of match expression with string literals.

In Rust, literals from match set are compared one by one; it is kind of like a big if-else chain. Instead, we can store a static lookup table (sorted by file name) and run a binary search over that. This should make file lookup more efficient in runtime and improve compile time too. This improves LLVM IR even for small uses of rust-embed; for examples/basic.rs a size of generated IR goes down by 7% from 4397 to 4082 lines. For a crate I'm working on this reduced LLVM IR size from 1.7M to 1.55M - RustEmbed is no longer the largest contributor to IR size.

I'd appreciate response to https://github.com/pyrossh/rust-embed/issues/216, as I had to mark `__rust_embed_new` as `const` to use it in array element initializer. This can probably be circumvented, though I think that this PR as a whole does not require a recent Rust version to work, so unless MSRV is very strict, we should be okay.