### PR TITLE
Changed the "items" constant to UPPER_CASE

### DIFF
--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -81,8 +81,8 @@ fn embedded(
           }
 
           fn names() -> std::slice::Iter<'static, &'static str> {
-              const items: [&str; #array_len] = [#(#list_values),*];
-              items.iter()
+              const ITEMS: [&str; #array_len] = [#(#list_values),*];
+              ITEMS.iter()
           }
 
           /// Iterates over the file paths in the folder.


### PR DESCRIPTION
Changed the "items" constant to UPPER_CASE for silence the "rust-analyzer(non_upper_case_globals)" warning.