### PR TITLE
Fix naming collisions in macros

### DIFF
--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -25,10 +25,7 @@ fn embedded(
   let includes: Vec<&str> = includes.iter().map(AsRef::as_ref).collect();
   let excludes: Vec<&str> = excludes.iter().map(AsRef::as_ref).collect();
   for rust_embed_utils::FileEntry { rel_path, full_canonical_path } in rust_embed_utils::get_files(absolute_folder_path.clone(), &includes, &excludes) {
-    match_values.insert(
-      rel_path.clone(),
-      embed_file(relative_folder_path.clone(), ident, &rel_path, &full_canonical_path)?,
-    );
+    match_values.insert(rel_path.clone(), embed_file(relative_folder_path, ident, &rel_path, &full_canonical_path)?);
 
     list_values.push(if let Some(prefix) = prefix {
       format!("{}{}", prefix, rel_path)

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -141,7 +141,7 @@ pub fn read_file_from_fs(file_path: &Path) -> io::Result<EmbeddedFile> {
   let hash: [u8; 32] = hasher.finalize().into();
 
   let source_date_epoch = match std::env::var("SOURCE_DATE_EPOCH") {
-    Ok(value) => value.parse::<u64>().map_or(None, |v| Some(v)),
+    Ok(value) => value.parse::<u64>().ok(),
     Err(_) => None,
   };
 


### PR DESCRIPTION
Previously the macro code wasn't using absolute paths in the code it generated, which could result in naming collisions from items the caller had in scope. This fixes such by making imports have absolute paths.

Currently the 'rust_embed' crate isn't absolutely scoped, as I'm unaware of a way to handle that reliably in proc macros (i.e. when the user renames the 'rust_embed' crate in their Cargo.toml). If that should be addressed in this PR I'm more than open to doing such, but even with this in itself it's still good progress compared to what was present before.

Closes #229.
