### PR TITLE
Allow users to specify a custom path to the rust_embed crate in generated code

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,8 @@ jobs:
           cargo test --test mime_guess --features "mime-guess" --release
           cargo test --test interpolated_path --features "interpolate-folder-path"
           cargo test --test interpolated_path --features "interpolate-folder-path" --release
+          cargo test --test custom_crate_path
+          cargo test --test custom_crate_path --release
           cargo build --example basic
           cargo build --example rocket --features rocket
           cargo build --example actix --features actix

--- a/tests/custom_crate_path.rs
+++ b/tests/custom_crate_path.rs
@@ -1,0 +1,20 @@
+/// This test checks that the `crate_path` attribute can be used
+/// to specify a custom path to the `rust_embed` crate.
+
+mod custom {
+  pub mod path {
+    pub use rust_embed;
+  }
+}
+
+// We introduce a 'rust_embed' module here to break compilation in case
+// the `rust_embed` crate is not loaded correctly.
+//
+// To test this, try commenting out the attribute which specifies the
+// the custom crate path -- you should find that the test fails to compile.
+mod rust_embed {}
+
+#[derive(custom::path::rust_embed::RustEmbed)]
+#[crate_path = "custom::path::rust_embed"]
+#[folder = "examples/public/"]
+struct Asset;


### PR DESCRIPTION
Hi @pyrossh, thanks for taking the time to maintain this crate and oversee the community's contributions :raised_hands: 

I'd like to request this feature: allow end users to specify a custom path to the rust_embed crate (in case `rust_embed` is not in-scope, for whatever reason).

### Changes
* Added a `crate_path` attribute which allows the end-user to specify the path to the rust_embed crate
    ```rust
    #[derive(custom::path::rust_embed::RustEmbed)]
    #[crate_path = "custom::path::rust_embed"] // <--
    #[folder = "examples/public/"]
    struct Asset;
    ```
* Added a test to make sure this doesn't break in the future :)

### Notes

* I tried to use `crate` as the attribute name instead of `crate_path` (just like serde does), but `proc_macro_derive` did not accept 'crate' as an attribute name.
