### PR TITLE
Eliminate unnecessary `to_path` call

### DIFF
--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -147,7 +147,7 @@ fn dynamic(ident: &syn::Ident, folder_path: String, prefix: Option<&str>, includ
                   // and check that instead if it starts with `canonical_folder_path`
                   // https://doc.rust-lang.org/std/path/fn.absolute.html (currently nightly)
                   // Should be allowed only if it was a symlink
-                  let metadata = ::std::fs::symlink_metadata(file_path.as_path()).ok()?;
+                  let metadata = ::std::fs::symlink_metadata(&file_path).ok()?;
                   if !metadata.is_symlink() {
                     return ::std::option::Option::None;
                   }


### PR DESCRIPTION
This is a minor simplification.

[symlink_metadata](https://doc.rust-lang.org/std/fs/fn.symlink_metadata.html) requires that its argument implement `AsRef<Path>`. `PathBuf` [implements this trait](https://doc.rust-lang.org/std/path/struct.PathBuf.html#impl-AsRef%3CPath%3E-for-PathBuf). Hence, the call to `to_path` is unnecessary.

Found with [Dylint](https://github.com/trailofbits/dylint/tree/master/examples/supplementary/unnecessary_conversion_for_trait), if interested.