### PR TITLE
Add `metadata_only` attribute

### DIFF
--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -125,6 +125,8 @@ fn dynamic(ident: &syn::Ident, folder_path: String, prefix: Option<&str>, includ
     const EXCLUDES: &[&str] = &[#(#excludes),*];
   };
 
+  // In metadata_only mode, we still need to read file contents to generate the file hash, but
+  // then we drop the file data.
   let strip_contents = metadata_only.then_some(quote! {
       .map(|mut file| { file.data = ::std::default::Default::default(); file })
   });

--- a/readme.md
+++ b/readme.md
@@ -75,11 +75,17 @@ If the feature `debug-embed` is enabled or the binary compiled in release mode a
 
 Otherwise the files are listed from the file system on each call.
 
-## The `prefix` attribute
+## Attributes
+### `prefix`
 
 You can add `#[prefix = "my_prefix/"]` to the `RustEmbed` struct to add a prefix
 to all of the file paths. This prefix will be required on `get` calls, and will
 be included in the file paths returned by `iter`.
+
+### `metadata_only`
+
+You can add `#[metadata_only = true]` to the `RustEmbed` struct to exclude file contents from the
+binary. Only file paths and metadata will be embedded.
 
 ## Features
 

--- a/tests/metadata_only.rs
+++ b/tests/metadata_only.rs
@@ -1,0 +1,12 @@
+use rust_embed::{EmbeddedFile, RustEmbed};
+
+#[derive(RustEmbed)]
+#[folder = "examples/public/"]
+#[metadata_only = true]
+struct Asset;
+
+#[test]
+fn file_is_empty() {
+  let index_file: EmbeddedFile = Asset::get("index.html").expect("index.html exists");
+  assert_eq!(index_file.data.len(), 0);
+}


### PR DESCRIPTION
Adds a `metadata_only` attribute which prevents the file contents from being included in the binary. For simplicity, this doesn't change the types -- it sets the file contents to empty byte slices.

Is this feature something you'd be open to adding?  I think this could be useful for other folks building wasm apps (which I talked about a bit in #238.)