### PR TITLE
Compatible with Axum 0.7.9

### DIFF
--- a/examples/axum-spa/main.rs
+++ b/examples/axum-spa/main.rs
@@ -17,8 +17,9 @@ async fn main() {
   let app = Router::new().fallback(static_handler);
 
   let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
+  let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
   println!("listening on {}", addr);
-  axum::Server::bind(&addr).serve(app.into_make_service()).await.unwrap();
+  axum::serve(listener, app.into_make_service()).await.unwrap();
 }
 
 async fn static_handler(uri: Uri) -> impl IntoResponse {


### PR DESCRIPTION
When exec `cargo run --example axum-spa --features axum-ex`:
<img width="742" alt="image" src="https://github.com/user-attachments/assets/2e2514ba-c138-47e0-89c8-36259f05c917" />

We check version in `Cargo.lock`:
<img width="631" alt="image" src="https://github.com/user-attachments/assets/26e674f3-f9d3-405f-948b-ee7fcc22ead4" />

Maybe API in Axum 0.7.9 has changed and we fix it