### PR TITLE
Add allow_missing option to derive macro

### DIFF
--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -379,7 +379,7 @@ fn impl_rust_embed(ast: &syn::DeriveInput) -> syn::Result<TokenStream2> {
 
   if !Path::new(&absolute_folder_path).exists() && !allow_missing {
     let mut message = format!(
-      "#[derive(RustEmbed)] folder '{}' does not exist. To allow the folder to be missing, add #[allow_missing]. cwd: '{}'",
+      "#[derive(RustEmbed)] folder '{}' does not exist. cwd: '{}'",
       absolute_folder_path,
       std::env::current_dir().unwrap().to_str().unwrap()
     );

--- a/readme.md
+++ b/readme.md
@@ -121,7 +121,7 @@ This will pull the `foo` directory relative to your `Cargo.toml` file.
 Compress each file when embedding into the binary. Compression is done via [`include-flate`].
 
 ### `include-exclude`
-Filter files to be embedded with multiple `#[include = "*.txt"]` and `#[exclude = "*.jpg"]` attributes.
+Filter files to be embedded with multiple `#[include = "*.txt"]` and `#[exclude = "*.jpg"]` attributes. 
 Matching is done on relative file paths, via [`globset`].
 `exclude` attributes have higher priority than `include` attributes.
 Example:

--- a/readme.md
+++ b/readme.md
@@ -93,6 +93,11 @@ be included in the file paths returned by `iter`.
 You can add `#[metadata_only = true]` to the `RustEmbed` struct to exclude file contents from the
 binary. Only file paths and metadata will be embedded.
 
+### `allow_missing`
+
+You can add `#[allow_missing = true]` to the `RustEmbed` struct to allow the embedded folder to be missing.
+In that case, RustEmbed will be empty.
+
 ## Features
 
 ### `debug-embed`
@@ -116,7 +121,7 @@ This will pull the `foo` directory relative to your `Cargo.toml` file.
 Compress each file when embedding into the binary. Compression is done via [`include-flate`].
 
 ### `include-exclude`
-Filter files to be embedded with multiple `#[include = "*.txt"]` and `#[exclude = "*.jpg"]` attributes. 
+Filter files to be embedded with multiple `#[include = "*.txt"]` and `#[exclude = "*.jpg"]` attributes.
 Matching is done on relative file paths, via [`globset`].
 `exclude` attributes have higher priority than `include` attributes.
 Example:

--- a/tests/allow_missing.rs
+++ b/tests/allow_missing.rs
@@ -1,0 +1,11 @@
+use rust_embed::Embed;
+
+#[derive(Embed)]
+#[folder = "examples/missing/"]
+#[allow_missing = true]
+struct Asset;
+
+#[test]
+fn missing_is_empty() {
+  assert_eq!(Asset::iter().count(), 0);
+}

--- a/tests/allow_missing.rs
+++ b/tests/allow_missing.rs
@@ -1,3 +1,5 @@
+use std::{path::PathBuf, str::FromStr};
+
 use rust_embed::Embed;
 
 #[derive(Embed)]
@@ -7,5 +9,7 @@ struct Asset;
 
 #[test]
 fn missing_is_empty() {
+  let path = PathBuf::from_str("./examples/missing").unwrap();
+  assert!(!path.exists());
   assert_eq!(Asset::iter().count(), 0);
 }


### PR DESCRIPTION
This can be helpful (but should not be enabled by default) for certain use cases.

Since it's off by default, it shouldn't compromise the safety of this macro.